### PR TITLE
Fix duplicate entries of master in node list

### DIFF
--- a/clustersosreport/clustersos.py
+++ b/clustersosreport/clustersos.py
@@ -197,10 +197,12 @@ class ClusterSos():
             if i in self.node_list:
                 self.node_list.remove(i)
         if self.config['master']:
-            if self.config['hostname'] in self.node_list:
-                self.node_list.remove(self.config['hostname'])
-            if self.config['master'] not in self.node_list:
-                self.node_list.append(self.config['master'])
+            count = 0
+            for n in self.node_list:
+                if n == self.master.hostname or n == self.config['master']:
+                    count +=1
+                    if count > 1:
+                        self.node_list.remove(n)
 
     def get_nodes(self):
         ''' Sets the list of nodes to collect sosreports from '''
@@ -208,7 +210,8 @@ class ClusterSos():
             self.node_list = [n for n in self.config['nodes'].split(',')]
         else:
             self.node_list = self.get_nodes_from_cluster()
-        self.node_list.append(self.config['hostname'])
+        if not self.config['master']:
+            self.node_list.append(self.config['hostname'])
         self.reduce_node_list()
         self.report_num = len(self.node_list)
         self.config['hostlen'] = len(max(self.node_list, key=len))

--- a/clustersosreport/sosnode.py
+++ b/clustersosreport/sosnode.py
@@ -22,13 +22,14 @@ from socket import timeout
 
 class SosNode():
 
-    def __init__(self, hostname, config):
-        self.hostname = hostname
+    def __init__(self, address, config):
+        self.address = address
         self.config = config
         self.sos_path = None
         self.retrieved = False
         self.host_facts = {}
         self.open_ssh_session()
+        self.get_hostname()
         self.load_host_facts()
 
     def info(self, msg):
@@ -46,6 +47,10 @@ class SosNode():
                                  )
         return cmd
 
+    def get_hostname(self):
+        sin, sout, serr = self.client.exec_command('hostname')
+        self.hostname = sout.read().strip()
+
     def sosreport(self):
         '''Run a sosreport on the node, then collect it'''
         self.finalize_sos_cmd()
@@ -61,7 +66,7 @@ class SosNode():
             self.client = paramiko.SSHClient()
             self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             self.client.load_system_host_keys()
-            self.client.connect(self.hostname,
+            self.client.connect(self.address,
                                 username=self.config['ssh_user'],
                                 timeout=15
                                 )


### PR DESCRIPTION
Previously it was possible that the master node would get added to the node list
twice, thus resulting in an extra unneeded sosreport. This would happen when
--master was an fqdn, and get_nodes from the cluster profile returned an ip
address, or vice versa.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>