### PR TITLE
Simplify how profiles are enabled

### DIFF
--- a/clustersosreport/profiles/kubernetes.py
+++ b/clustersosreport/profiles/kubernetes.py
@@ -19,21 +19,17 @@ class kubernetes(Profile):
 
     sos_plugins = ['kubernetes']
     sos_options = {'kubernetes.all': 'on'}
+    packages = ('kubernetes-master', 'atomic-openshift-master')
 
     option_list = [
                 ('label', 'Restrict nodes to those with matching label')
                 ]
 
-    def check_enabled(self):
-        if 'kubernetes-master' in self.config['packages']:
-            self.cmd = 'kubectl '
-            return True
-        if 'atomic-openshift-master' in self.config['packages']:
-            self.cmd = 'oc '
-            return True
-        return False
-
     def get_nodes(self):
+        if self.is_installed('atomic-openshift-master'):
+            self.cmd = 'oc '
+        else:
+            self.cmd = 'kubectl '
         self.cmd += 'get nodes '
         if self.get_option('label'):
             self.cmd += '-l %s ' % self.get_option('label')

--- a/clustersosreport/profiles/pacemaker.py
+++ b/clustersosreport/profiles/pacemaker.py
@@ -16,12 +16,8 @@ from profile import Profile
 
 class pacemaker(Profile):
 
-    sos_plugins = {'pacemaker'}
-
-    def check_enabled(self):
-        if 'pacemaker' in self.config['packages']:
-            return True
-        return False
+    sos_plugins = ['pacemaker']
+    packages = ('pacemaker',)
 
     def get_nodes(self):
         cmd = 'pcs status'

--- a/clustersosreport/profiles/profile.py
+++ b/clustersosreport/profiles/profile.py
@@ -23,6 +23,8 @@ class Profile():
         self.cluster_type = self.__class__.__name__
         self.node_list = None
         sos_plugins = []
+        if not getattr(self, 'packages', False):
+            self.packages = ('',)
         if not getattr(self, 'sos_options', False):
             self.sos_options = {}
         if not getattr(self, "option_list", False):
@@ -45,6 +47,9 @@ class Profile():
             if option == opt[0]:
                 return opt[1]
         return False
+
+    def is_installed(self, pkg):
+        return pkg in self.config['packages']
 
     def exec_master_cmd(self, cmd):
         '''Used to retrieve output from a (master) node in a cluster
@@ -119,13 +124,16 @@ class Profile():
         return ''
 
     def check_enabled(self):
-        '''This should be overridden by cluster profiles
+        '''This may be overridden by cluster profiles
 
         This is called by clustersos on each profile that exists, and is
         meant to return True when the cluster profile matches a criteria
         that indicates that cluster type is in use.
 
         Only the first cluster type to determine a match is run'''
+        for pkg in self.packages:
+            if pkg in self.config['packages']:
+                return True
         return False
 
     def get_nodes(self):


### PR DESCRIPTION
This simplifies the way profiles are enabled. Instead of writing a
check_enabled() method for each profile, the profiles now just need to set a
'packages' tuple with the names of the package(s) the profile should be enabled
for.

Also corrected the kubernetes profile to use the correct command for OpenShift
clusters.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>