### PR TITLE
Fix return of command output when run locally.

### DIFF
--- a/clustersos/profiles/__init__.py
+++ b/clustersos/profiles/__init__.py
@@ -79,7 +79,8 @@ class Profile():
         stdout, stderr = proc.communicate()
         rc = proc.returncode
         if proc.returncode == 0:
-            return str(stdout, 'utf-8')
+            sout = stdout.read().splitlines()
+            return ([s.decode('utf-8') for s in sout] or True)
         return False
 
     def get_sos_prefix(self, facts):


### PR DESCRIPTION
Resolves #6.

Returns a list instead of a string for command output when run locally.
This matches the behavior of running remotely.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>